### PR TITLE
[FEATURE] Add permissions check for setfilepermissions.sh

### DIFF
--- a/Scripts/flow.php
+++ b/Scripts/flow.php
@@ -20,6 +20,10 @@ if (PHP_SAPI !== 'cli') {
 }
 
 if (isset($argv[1]) && ($argv[1] === 'typo3.flow:core:setfilepermissions' || $argv[1] === 'flow:core:setfilepermissions' || $argv[1] === 'core:setfilepermissions')) {
+    $perms = decoct(fileperms(__DIR__. '/setfilepermissions.sh') & 0777);
+        if ($perms != '700'){
+                chmod(__DIR__. '/setfilepermissions.sh', 0700);
+        }
     if (DIRECTORY_SEPARATOR !== '/') {
         exit('The core:setfilepermissions command is only available on UNIX platforms.' . PHP_EOL);
     }


### PR DESCRIPTION
Using the setfilepermissions.sh script fails due to wrong file permissions left by the composer installation (missing executable bit). Added the checking of the file's permissions, and correcting the file's permissions if needed.
