### PR TITLE
Remove value for optional parameter as it is the default

### DIFF
--- a/Classes/Cache/CacheFactory.php
+++ b/Classes/Cache/CacheFactory.php
@@ -90,8 +90,7 @@ class CacheFactory extends \Neos\Cache\CacheFactory implements CacheFactoryInter
 
         $environmentConfiguration = new EnvironmentConfiguration(
             FLOW_PATH_ROOT . '~' . (string)$environment->getContext(),
-            $environment->getPathToTemporaryDirectory(),
-            PHP_MAXPATHLEN
+            $environment->getPathToTemporaryDirectory()
         );
 
         parent::__construct($environmentConfiguration);


### PR DESCRIPTION
In environment configuration class the parameter is optional and the default value is the same as the value to set