### PR TITLE
Update Security.rst

### DIFF
--- a/Documentation/TheDefinitiveGuide/PartIII/Security.rst
+++ b/Documentation/TheDefinitiveGuide/PartIII/Security.rst
@@ -781,7 +781,7 @@ methods.
         matcher: 'method(Acme\MyPackage\Controller\RestrictedController->adminAction())'
 
       'Acme.MyPackage:editOwnPost':
-        matcher: 'method(Acme\MyPackage\Controller\PostController->editAction(post.owner == current.userService.currentUser))'
+        matcher: 'method(Acme\MyPackage\Controller\PostController->editAction(post.owner.accounts.0 == current.securityContext.account))'
 
 
 


### PR DESCRIPTION
The Example with current.userService.currentUser does not exist / work.

The class Neos\Neos\Service\UserService (provided as userInformation) does not offer a currentUser property nor a getCurrentUser method.